### PR TITLE
chore: add configuration for server port - change default port to 888…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-mcp",
-  "version": "0.0.26",
+  "version": "0.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-mcp",
-      "version": "0.0.26",
+      "version": "0.0.29",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.1.15",
         "@ai-sdk/openai-compatible": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "displayName": "Copilot MCP",
   "description": "VSCode extension that acts as a Model Context Protocol (MCP) client, enabling integration between MCP servers and GitHub Copilot Chat",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "icon": "logo.png",
   "engines": {
     "vscode": "^1.97.0"
@@ -335,6 +335,11 @@
               }
             }
           }
+        },
+        "mcpManager.serverPort": {
+          "type": "number",
+          "default": 8888,
+          "description": "Port number for MCP server"
         }
       }
     }

--- a/src/extension/sse-client.ts
+++ b/src/extension/sse-client.ts
@@ -13,7 +13,7 @@ export async function baseClient(): Promise<{ client: Client, tools: Tool[], dis
         capabilities: {}
     });
     const transport = new SSEClientTransport(
-        new URL("http://localhost:8080/sse")
+        new URL("http://localhost:8888/sse")
     );
 
     try {

--- a/src/extension/sse-server.ts
+++ b/src/extension/sse-server.ts
@@ -6,7 +6,7 @@ import express, { Response } from 'express';
 /**
  * Start the MCP server using WebSocket transport
  */
-export async function startSseMcpServer(port = 8080, hostname = 'localhost', server: McpServer) {
+export async function startSseMcpServer(port = 8888, hostname = 'localhost', server: McpServer) {
 
     const app = express();
 

--- a/src/extension/tools/mcp-tools.ts
+++ b/src/extension/tools/mcp-tools.ts
@@ -189,6 +189,10 @@ function convertTreeToMarkdown(
 
 // Create the MCP server with VS Code tools
 export async function createMcpServer() {
+    // Get port from configuration
+    const config = vscode.workspace.getConfiguration('mcpManager');
+    const port = config.get<number>('serverPort') || 8888;
+
     // Static variables for file edit tool
     const previewScheme = 'fileedit-preview';
     const previewProvider = new EditPreviewProvider();
@@ -461,9 +465,7 @@ export async function createMcpServer() {
             }
         }
     );
-    return await startSseMcpServer(8080, 'localhost', server);
-
-
+    return await startSseMcpServer(port, 'localhost', server);
 }
 
 // Function to start the server with express and SSE transport
@@ -485,6 +487,4 @@ export async function startMcpServer() {
             server.dispose();
         }
     };
-
-
 }


### PR DESCRIPTION
`8080` is default http port that a lot of frameworks uses to locally deploy services.
This causes collisions and degrades experience.

- Added serverPort configuration to change MCP Server port.
- Changed default port from 8080 to 8888
- Bump version

