### PR TITLE
fix: sync workflow YAML + pre-commit version bump hook

### DIFF
--- a/.github/workflows/sync-opencode-copilot.yml
+++ b/.github/workflows/sync-opencode-copilot.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           branch: chore/sync-opencode-copilot
           delete-branch: false
-          title: chore: sync opencode copilot provider
+          title: "chore: sync opencode copilot provider"
           commit-message: "chore: sync opencode copilot provider to ${{ steps.upstream.outputs.commit }}"
           body: |
             Automated sync of vendored Copilot provider sources.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+node scripts/bump-version-on-extension-change.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ When adding or changing extension/webview behavior:
   - root-level export-oriented variant: `skills-client.ts`
   Keep behavior aligned if shared APIs change.
 - Vendored Copilot provider source of truth is `vendor/opencode-copilot/src/**`, synced via `scripts/sync-opencode-copilot.mjs`. Do not hand-edit vendored source files.
-- A Husky pre-commit hook auto-bumps `package.json` patch version (and stages `package-lock.json`) when staged extension source changes are detected under `src/**` or `web/src/**` (excluding tests).
+- A Husky pre-commit hook auto-bumps `package.json` patch version and stages `package.json` plus `package-lock.json` when staged extension source changes are detected under `src/**` or `web/src/**` (excluding tests).
 - UI harness entry points:
   - webview tests: `web/vitest.config.ts`, `web/src/test/setup.ts`
   - extension UI harness: `src/test/ui/runTest.ts`, `src/test/ui/suite/**`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ When adding or changing extension/webview behavior:
   - root-level export-oriented variant: `skills-client.ts`
   Keep behavior aligned if shared APIs change.
 - Vendored Copilot provider source of truth is `vendor/opencode-copilot/src/**`, synced via `scripts/sync-opencode-copilot.mjs`. Do not hand-edit vendored source files.
+- A Husky pre-commit hook auto-bumps `package.json` patch version (and stages `package-lock.json`) when staged extension source changes are detected under `src/**` or `web/src/**` (excluding tests).
 - UI harness entry points:
   - webview tests: `web/vitest.config.ts`, `web/src/test/setup.ts`
   - extension UI harness: `src/test/ui/runTest.ts`, `src/test/ui/suite/**`

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@vscode/test-electron": "^2.5.2",
         "esbuild": "^0.25.3",
         "eslint": "^9.25.1",
+        "husky": "^9.1.7",
         "mocha": "^11.7.5",
         "typescript": "^5.8.3",
         "vscode-extension-tester": "^8.21.0"
@@ -6193,6 +6194,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     }
   },
   "scripts": {
+    "prepare": "husky",
     "install:all": "npm install && npm --prefix web install",
     "start:webview": "cd web && npm run start",
     "build:webview": "npm --prefix web run build",
@@ -208,6 +209,7 @@
     "@vscode/test-electron": "^2.5.2",
     "esbuild": "^0.25.3",
     "eslint": "^9.25.1",
+    "husky": "^9.1.7",
     "mocha": "^11.7.5",
     "typescript": "^5.8.3",
     "vscode-extension-tester": "^8.21.0"

--- a/scripts/bump-version-on-extension-change.mjs
+++ b/scripts/bump-version-on-extension-change.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import process from "node:process";
+
+const WATCHED_PATHS = [/^src\//, /^web\/src\//];
+const IGNORED_PATHS = [
+  /^src\/test\//,
+  /^web\/src\/test\//,
+  /^web\/src\/.*\.test\.[cm]?[jt]sx?$/,
+  /^src\/.*\.test\.[cm]?ts$/,
+];
+
+function runGit(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function runCommand(command, args) {
+  execFileSync(command, args, {
+    stdio: "inherit",
+  });
+}
+
+function getStagedFiles() {
+  const output = runGit(["diff", "--cached", "--name-only", "--diff-filter=ACMR"]);
+  if (!output) {
+    return [];
+  }
+
+  return output.split("\n").map((file) => file.trim()).filter(Boolean);
+}
+
+function isExtensionSourceFile(filePath) {
+  if (!WATCHED_PATHS.some((pattern) => pattern.test(filePath))) {
+    return false;
+  }
+  if (IGNORED_PATHS.some((pattern) => pattern.test(filePath))) {
+    return false;
+  }
+  return true;
+}
+
+function readVersionFromGitObject(revisionSpec) {
+  const packageJson = runGit(["show", revisionSpec]);
+  const parsed = JSON.parse(packageJson);
+  if (typeof parsed.version !== "string" || parsed.version.length === 0) {
+    throw new Error(`Could not read version from ${revisionSpec}`);
+  }
+  return parsed.version;
+}
+
+function stageVersionFiles() {
+  const filesToStage = ["package.json"];
+  if (existsSync("package-lock.json")) {
+    filesToStage.push("package-lock.json");
+  }
+  runGit(["add", ...filesToStage]);
+}
+
+function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const stagedFiles = getStagedFiles();
+  const extensionChanges = stagedFiles.filter((filePath) => isExtensionSourceFile(filePath));
+
+  if (extensionChanges.length === 0) {
+    return;
+  }
+
+  const headVersion = readVersionFromGitObject("HEAD:package.json");
+  const indexVersion = readVersionFromGitObject(":package.json");
+
+  if (headVersion !== indexVersion) {
+    console.log(`[version-bump] Version already changed (${headVersion} -> ${indexVersion}); skipping auto-bump.`);
+    return;
+  }
+
+  console.log("[version-bump] Extension source changes detected in staged files:");
+  for (const filePath of extensionChanges) {
+    console.log(`[version-bump] - ${filePath}`);
+  }
+
+  if (dryRun) {
+    console.log("[version-bump] Dry run enabled; skipping version bump.");
+    return;
+  }
+
+  runCommand("npm", ["version", "patch", "--no-git-tag-version"]);
+  stageVersionFiles();
+
+  const nextVersion = readVersionFromGitObject(":package.json");
+  console.log(`[version-bump] Bumped version ${headVersion} -> ${nextVersion} and staged version files.`);
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[version-bump] ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- fix invalid YAML in sync workflow PR title value
- add Husky pre-commit hook to auto-bump patch version when staged extension source changes
- stage package version files automatically during commit

## Included commits
- b21c438 fix: quote sync workflow PR title for valid YAML
- 550817c chore: add pre-commit auto version bump for extension changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatic patch version bumping now runs when extension/source changes are committed; related manifest files are staged.
  * A pre-commit hook was added to run the version-bump check and enforce staging.
  * Tooling updated to enable and prepare pre-commit hooks in the repo.

* **Documentation**
  * Developer docs updated to document the pre-commit hook and CI test harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->