### PR TITLE
release 0.0.95: AI-assisted setup works again + telemetry quality (#57, #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 *Sponsored by [Cloud MCP](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=marketplace&utm_campaign=marketplace-changelog) – Deploy remote MCP servers in seconds.*
 
+## [0.0.95] - 2026-06-12
+
+### Fixed
+
+- AI-assisted setup works again. It was hardcoded to the `gpt-5.2-codex` Copilot model, which GitHub retired on 2026-06-01, causing every setup attempt to fail. The extension now resolves a currently-available model from your Copilot account's live `/models` catalog (preferring `claude-sonnet-4.6`, then `gpt-5.3-codex`), with a known-good fallback if the catalog can't be reached.
+- AI-assisted setup failures now surface the real underlying cause (including the actual HTTP status and error returned by the language model) to diagnostics, instead of a generic, undiagnosable failure.
+- The What's New notes now render on VS Code forks/OSS builds that don't ship the built-in Markdown preview command, falling back to opening the notes as a document or on the web.
+
+### Changed
+
+- Failure-driven "Deploy on CloudMCP" clicks (from the failed-setup card) are now attributed separately from normal repo-card deploys — distinct campaign plus a `surface` telemetry property — so we can tell how often the hosted fallback rescues a failed setup. The destination is unchanged.
+- Error and auth telemetry was tightened — still minimal and anonymous; see the Telemetry section in the README for what is collected.
+
 ## [0.0.94] - 2026-06-11
 
 ### Added

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,6 +1,19 @@
 # What's New in Copilot MCP!
 
-*Sponsored by [Cloud MCP](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=whats-new-0.0.94) - Try out Cloud MCP's [Router Mode](https://cloudmcp.run/blog/cloud-mcp-router?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=whats-new-0.0.94) that significantly improves tool calling success by AI agents!*
+*Sponsored by [Cloud MCP](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=whats-new-0.0.95) - Try out Cloud MCP's [Router Mode](https://cloudmcp.run/blog/cloud-mcp-router?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=whats-new-0.0.95) that significantly improves tool calling success by AI agents!*
+
+## Version 0.0.95 - AI-Assisted Setup Works Again
+*(June 12 2026)*
+
+AI-assisted setup had stopped working: it was pinned to a GitHub Copilot model that was retired on June 1, so every setup attempt failed. This release picks a live model automatically and makes failures explain themselves — and when setup still can't complete, the existing hosted fallback now reports separately so we can see how often it rescues a failed setup.
+
+What's new
+
+- **AI-assisted setup picks a working model automatically.** It was hardwired to a single Copilot model (`gpt-5.2-codex`) that GitHub retired on June 1 2026 — so once that model went away, every AI-assisted setup failed. The extension now queries your Copilot account's live list of available models and uses one that's actually enabled (preferring Claude Sonnet 4.6, then the current GPT-5.3 Codex), with a known-good default if the list can't be reached. Setup works again, and it won't break the next time a single model is retired.
+- **Failures explain themselves.** When AI-assisted setup can't finish, the real underlying reason (including the actual error returned by the language model) now reaches the diagnostics instead of a generic "it failed" — so a problem can be understood and fixed instead of guessed at.
+- **The hosted fallback now reports separately.** When AI-assisted setup fails, the card's existing **Deploy on CloudMCP** button still takes you to the [hosted catalog](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=whats-new-0.0.95) for that server — and those failure-driven clicks are now attributed apart from ordinary repo-card deploys, so we can tell how often the fallback rescues a failed setup.
+- **The What's New notes show up everywhere.** On VS Code forks that don't ship the built-in Markdown preview, these notes now open as a document (or on the web) instead of silently failing.
+- **Telemetry tune-up** for error and auth reporting — still minimal and anonymous; details in the [README Telemetry section](https://github.com/VikashLoomba/copilot-mcp#telemetry).
 
 ## Version 0.0.94 - The Installed Tab Sees Everything + Run on CloudMCP
 *(June 11 2026)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-mcp",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-mcp",
-      "version": "0.0.94",
+      "version": "0.0.95",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^0.2.14",
         "@ax-llm/ax": "^14.0.16",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "displayName": "Copilot MCP + Agent Skills Manager",
   "description": "Search, manage, and install Skills and MCP servers for your AI agents.",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "icon": "logo.png",
   "engines": {
     "vscode": "^1.104.0"

--- a/src/McpAgent.ts
+++ b/src/McpAgent.ts
@@ -296,11 +296,15 @@ export const handler: vscode.ChatRequestHandler = async (
 			
 			return result;
 		} catch (error) {
-			// Log error with standardized error telemetry
+			// Log error with standardized error telemetry. Spread the extracted
+			// cause (the real HTTP status buried on .cause by @ax-llm/ax —
+			// issue #57) so README-extraction failures are diagnosable instead
+			// of error_class=unknown.
 			logError(error as Error, 'chat-install', {
 				query: request.prompt,
 				queryLength: request.prompt.length,
 				command: request.command,
+				...describeErrorCause(error),
 			});
 			
 			// Also end performance timer for failed operations
@@ -479,6 +483,43 @@ function tagStage(error: unknown, stage: AiSetupStage): unknown {
 	return error;
 }
 
+// @ax-llm/ax's AxGen wraps service failures as a bare AxGenerateError
+// ("Generate failed") and hangs the real AxAIServiceStatusError off .cause, so
+// the HTTP status (e.g. the 4xx from a retired model — issue #57) never reaches
+// the surface error.message. Duck-types the cause chain (avoids fragile
+// cross-bundle instanceof) to pull the real status/message for telemetry.
+// Returns only contract-safe, low-cardinality props (numeric cause_status,
+// truncated cause_message); no secret-substring keys.
+export function describeErrorCause(
+	error: unknown,
+): { cause_status?: number; cause_message?: string } {
+	let current: unknown =
+		typeof error === "object" && error !== null
+			? (error as { cause?: unknown }).cause
+			: undefined;
+	for (let depth = 0; depth < 4 && current && typeof current === "object"; depth++) {
+		const c = current as {
+			status?: unknown;
+			statusText?: unknown;
+			message?: unknown;
+			cause?: unknown;
+		};
+		if (typeof c.status === "number") {
+			const statusText =
+				typeof c.statusText === "string" ? c.statusText : undefined;
+			const message =
+				typeof c.message === "string" ? c.message : undefined;
+			const detail = statusText || message;
+			return {
+				cause_status: c.status,
+				...(detail ? { cause_message: detail.slice(0, 200) } : {}),
+			};
+		}
+		current = c.cause;
+	}
+	return {};
+}
+
 export async function readmeExtractionRequest(readme: string) {
 	let provider: AxAI;
 	try {
@@ -517,6 +558,13 @@ export async function readmeExtractionRequest(readme: string) {
 			inputs: object.inputs
 		};
 	} catch (error) {
+		// Do NOT log here: every caller already emits exactly one rich
+		// ext.error.general for this attempt (panel 'ai-assisted-setup' with the
+		// attempt_id, chat 'chat-install'). Logging a second 'readme-extraction'
+		// event would double-count the issue #57 metric and lose the attempt_id
+		// correlation. Instead tag the stage and let the caller spread
+		// describeErrorCause(err) into its single event to surface the buried
+		// HTTP status (e.g. the 4xx from a retired model).
 		throw tagStage(error, "extract");
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -273,10 +273,42 @@ async function showUpdatesToUser(context: vscode.ExtensionContext) {
 			whatsNewUri = remoteUri;
 			whatsNewSource = "remote";
 		}
-		await vscode.commands.executeCommand(
-			"markdown.showPreview",
-			whatsNewUri,
-		);
+		// Render the notes. The built-in Markdown preview command is absent on
+		// some VS Code forks/OSS builds (it lives in the bundled markdown
+		// extension), so fall back to opening the markdown source in an editor
+		// and, failing that, the notes on the web. The impression is recorded
+		// as long as SOME render path succeeds.
+		let rendered = false;
+		try {
+			await vscode.commands.executeCommand(
+				"markdown.showPreview",
+				whatsNewUri,
+			);
+			rendered = true;
+		} catch (previewError) {
+			outputLogger.debug(
+				"markdown.showPreview unavailable; opening notes as plain document",
+				previewError as Error,
+			);
+			try {
+				await vscode.window.showTextDocument(whatsNewUri);
+				rendered = true;
+			} catch (showDocError) {
+				outputLogger.debug(
+					"Opening notes document failed; opening notes on the web",
+					showDocError as Error,
+				);
+				rendered = await vscode.env.openExternal(
+					vscode.Uri.parse(WHATS_NEW_REMOTE_URL),
+				);
+			}
+		}
+
+		// If every render path failed, leave the stored version untouched so we
+		// try again on the next activation, and skip the impression event.
+		if (!rendered) {
+			return;
+		}
 
 		// Persist that we've shown the notes for this version so we don't show again
 		await context.globalState.update(storageKey, currentVersion);

--- a/src/panels/ExtensionPanel.ts
+++ b/src/panels/ExtensionPanel.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { getNonce } from "../utilities/getNonce";
 import { getUri } from "../utilities/getUri";
 import { searchMcpServers2 } from "../utilities/repoSearch";
-import { openMcpInstallUri, readmeExtractionRequest } from "../McpAgent";
+import { openMcpInstallUri, readmeExtractionRequest, describeErrorCause } from "../McpAgent";
 import type { AiSetupStage } from "../McpAgent";
 import { 
 	logWebviewSearch, 
@@ -1337,7 +1337,12 @@ export class CopilotMcpViewProvider implements vscode.WebviewViewProvider {
 		});
 
 		messenger.onNotification(cloudMCPInterestType, async (payload) => {
-			// Log CloudMCP interest with telemetry
+			// Where the click originated. Older webviews omit `surface`; default to
+			// the normal repo-card deploy so legacy clicks remain attributed.
+			const surface = payload.surface === 'ai_setup_failure' ? 'ai_setup_failure' : 'repo_card';
+
+			// Log CloudMCP interest with telemetry. `surface` lets a failure-driven
+			// deploy click be told apart from a casual one in the funnel.
 			logEvent({
 				name: 'webview.cloudmcp.interest',
 				properties: {
@@ -1345,6 +1350,7 @@ export class CopilotMcpViewProvider implements vscode.WebviewViewProvider {
 					repoOwner: payload.repoOwner,
 					repoUrl: payload.repoUrl,
 					timestamp: payload.timestamp,
+					surface,
 				},
 			});
 
@@ -1357,10 +1363,14 @@ export class CopilotMcpViewProvider implements vscode.WebviewViewProvider {
 				? repoName
 				: (repoOwner && repoName ? `${repoOwner}/${repoName}` : '');
 
+			// A failure-driven deploy is a distinct, measurable campaign; a casual
+			// repo-card deploy keeps its existing campaign.
+			const utmCampaign = surface === 'ai_setup_failure' ? 'deploy-setup-fallback' : 'deploy-repo-card';
+
 			// Deep link to the dashboard discover page for this repo, falling back
 			// to the main CloudMCP dashboard when the repo identity is absent
 			const deployUrl = repoSlug
-				? `https://cloudmcp.run/dashboard/discover?q=${encodeURIComponent(repoSlug)}&utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=deploy-repo-card`
+				? `https://cloudmcp.run/dashboard/discover?q=${encodeURIComponent(repoSlug)}&utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=${utmCampaign}`
 				: 'https://cloudmcp.run/dashboard?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=deploy';
 
 			// Open external URL with proper referrer tracking
@@ -1594,11 +1604,15 @@ export class CopilotMcpViewProvider implements vscode.WebviewViewProvider {
 					const stage = getAiSetupStage(err);
 					const lmCode = err instanceof vscode.LanguageModelError ? err.code : undefined;
 					// Log exactly one rich ext.error.general for this attempt,
-					// correlated with the ai_setup funnel via attempt_id.
+					// correlated with the ai_setup funnel via attempt_id. Spread the
+					// extracted cause (the real HTTP status buried on .cause by
+					// @ax-llm/ax — issue #57) so the failure is diagnosable instead of
+					// error_class=unknown/lm_code=NULL.
 					logError(err, 'ai-assisted-setup', {
 						...(attemptId && { attemptId }),
 						...(stage && { stage }),
 						...(lmCode && { lm_code: lmCode }),
+						...describeErrorCause(err),
 					});
 					// Making the chat request might fail because
 					// - model does not exist

--- a/src/shared/types/rpcTypes.ts
+++ b/src/shared/types/rpcTypes.ts
@@ -69,11 +69,20 @@ export const aiAssistedSetupType: RequestType<{repo: any; cloudMcpDetails?: Clou
 
 export const sendFeedbackType: NotificationType<{ feedback: string }> = { method: "sendFeedback" };
 
-export const cloudMCPInterestType: NotificationType<{ 
-	repoName: string; 
+// Where the CloudMCP-interest action originated in the RepoCard UI. Additive
+// and optional for backward compatibility: older webviews omit it, and the
+// panel defaults to "repo_card".
+// - "repo_card": the normal "Deploy on CloudMCP" button.
+// - "ai_setup_failure": the "Deploy on CloudMCP" button shown in the
+//   AI-assisted-setup failure (installError) state.
+export type CloudMcpInterestSurface = "repo_card" | "ai_setup_failure";
+
+export const cloudMCPInterestType: NotificationType<{
+	repoName: string;
 	repoOwner: string;
 	repoUrl: string;
 	timestamp: string;
+	surface?: CloudMcpInterestSurface;
 }> = { method: "cloudMCPInterest" };
 
 export const checkCloudMcpType: RequestType<{

--- a/src/utilities/CopilotChat.ts
+++ b/src/utilities/CopilotChat.ts
@@ -1,13 +1,90 @@
 import * as vscode from "vscode";
 
 import { ai, AxAI, AxAIOpenAIModel } from "@ax-llm/ax";
-import { logError } from "../telemetry/standardizedTelemetry";
+import { logError, logEvent } from "../telemetry/standardizedTelemetry";
 
 const GITHUB_AUTH_PROVIDER_ID = "github";
 // The GitHub Authentication Provider accepts the scopes described here:
 // https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
 const SCOPES = ["user:email", "read:org", "read:user"];
 const GITHUB_COPILOT_CLIENT_ID = "Iv1.b507a08c87ecfe98"; // This is a public client ID for Copilot
+
+// Known-good fallback model used when the live Copilot /models catalog cannot
+// be reached or returns nothing usable. Must be a currently-GA Copilot model:
+// 'gpt-5.2-codex' was retired 2026-06-01, so we lead getModelId() with
+// claude-sonnet-4.6 (safest for structured extraction) and fall back here.
+const FALLBACK_MODEL_ID = "gpt-5.3-codex";
+// Upper bound on the live /models lookup during provider construction so a slow
+// or hung catalog request can never stall initialization; on timeout we use the
+// fallback model instead.
+const MODEL_RESOLUTION_TIMEOUT_MS = 4000;
+
+/**
+ * True when a failed background auth/token attempt is an *expected* unavailable
+ * state (the user is simply signed out or offline) rather than a real fault.
+ * These dominate error.general volume during the activation-time auth probe
+ * (issue #58.3: "device_code has expired", "fetch failed"), so they are routed
+ * to a non-error signal instead. Matches conservatively on the underlying
+ * error/cause text so genuine faults still surface as errors.
+ */
+function isExpectedBackgroundAuthFailure(error: unknown): boolean {
+	const parts: string[] = [];
+	let current: unknown = error;
+	// Walk the cause chain (bounded) so a wrapped 'fetch failed' is still seen.
+	for (let depth = 0; depth < 4 && current; depth++) {
+		if (typeof current === "string") {
+			parts.push(current);
+			break;
+		}
+		if (typeof current === "object") {
+			const e = current as { message?: unknown; cause?: unknown };
+			if (typeof e.message === "string") {
+				parts.push(e.message);
+			}
+			current = e.cause;
+		} else {
+			break;
+		}
+	}
+	const text = parts.join(" ").toLowerCase();
+	return (
+		text.includes("device_code has expired") ||
+		text.includes("device_code") ||
+		text.includes("expired_token") ||
+		text.includes("authorization_pending") ||
+		text.includes("slow_down") ||
+		text.includes("fetch failed") ||
+		text.includes("network") ||
+		text.includes("enotfound") ||
+		text.includes("econnrefused") ||
+		text.includes("etimedout") ||
+		text.includes("offline")
+	);
+}
+
+/**
+ * Records an expected "auth not available" condition as a non-error telemetry
+ * signal (ext.auth.unavailable) so background probe failures don't inflate
+ * error.general. Fail-safe: never throws into the caller. `reason` is a short,
+ * non-secret label (no 'token'/'secret'/'auth'/'key'/'user'/'session' key).
+ */
+function logAuthUnavailable(error: unknown, site: string): void {
+	try {
+		const cls =
+			error instanceof Error
+				? error.constructor?.name || "Error"
+				: typeof error;
+		logEvent({
+			name: "auth.unavailable",
+			properties: {
+				reason: site.slice(0, 32),
+				cause_class: cls.slice(0, 200),
+			},
+		});
+	} catch {
+		// Telemetry must never break auth flow.
+	}
+}
 
 export class CopilotChatProvider {
 	public _context: vscode.ExtensionContext | undefined;
@@ -35,8 +112,12 @@ export class CopilotChatProvider {
 			throw new Error("CopilotChatProvider is not initialized");
 		}
 		if (!this._provider) {
+			// Use the model resolved from the live Copilot /models catalog during
+			// initialization (see resolveBaseModel). If that never ran or came up
+			// empty, fall back to a known-good GA model rather than a retired one.
+			const model = this._baseModel || FALLBACK_MODEL_ID;
 			this.provider = ai(
-				//@ts-expect-error config.model returns error but this is a valid model.
+				//@ts-expect-error config.model is typed as the AxAIOpenAIModel enum, but the live Copilot catalog id is a valid model string.
 				{
 					name: "openai",
 					apiKey: this.copilotToken,
@@ -54,7 +135,7 @@ export class CopilotChatProvider {
 						},
 					},
 					config: {
-						model: "gpt-5.2-codex",
+						model,
 					},
 				},
 			);
@@ -151,8 +232,13 @@ export class CopilotChatProvider {
 			this.session = session;
 			this.copilotToken = undefined;
 			this._provider = undefined;
+			this._baseModel = "";
 			this._headers = { ...this.defaultHeaders };
-			await this.getCopilotToken(this._context!);
+			await this.getCopilotToken(this._context!, interactive);
+			// Resolve the chat model from the live Copilot /models catalog now that
+			// the bearer header is set, so the (synchronous) provider getter can read
+			// a current model id instead of a hardcoded — and possibly retired — one.
+			await this.resolveBaseModel();
 			const existingSessions = await vscode.authentication.getAccounts(
 				GITHUB_AUTH_PROVIDER_ID,
 			);
@@ -161,7 +247,11 @@ export class CopilotChatProvider {
 			console.log("CopilotChatProvider initialization complete");
 		} catch (error) {
 			if (interactive) {
-				logError(error as Error, "github-authentication", {
+				// error_site renamed off 'github-authentication': the substring
+				// 'auth' is PII-scrubbed by the telemetry sender, which blinded
+				// these events (issue #58.1). 'github-signin' carries no
+				// secret-pattern substring.
+				logError(error as Error, "github-signin", {
 					provider: GITHUB_AUTH_PROVIDER_ID,
 					scopes: SCOPES.join(","),
 					createIfNone: interactive,
@@ -170,12 +260,33 @@ export class CopilotChatProvider {
 					"GitHub authentication failed. Please sign in to GitHub.",
 				);
 				throw error;
+			} else {
+				// Background (silent) probe: a missing/expired session is the
+				// expected steady state for signed-out users, not an error, so it
+				// must never reach error.general (issue #58.3). Token-exchange
+				// failures already self-report inside getCopilotToken and arrive
+				// here flagged telemetryReported; this outer branch then only
+				// emits for the rarer getSession-origin faults, which during a
+				// silent probe are themselves an "auth unavailable" condition.
+				// Emit the non-error signal and wait for a user-triggered call.
+				const reported =
+					typeof error === "object" &&
+					error !== null &&
+					(error as { telemetryReported?: boolean }).telemetryReported === true;
+				if (!reported) {
+					logAuthUnavailable(error, "signin-probe");
+				}
+				console.warn("Silent GitHub initialization failed", error);
 			}
 		}
 	}
 
 	private async getCopilotToken(
 		context: vscode.ExtensionContext,
+		// True only for user-initiated flows. Defaults to background-safe so any
+		// future caller is treated as a silent probe (expected-unavailable
+		// failures are not surfaced as errors) unless it opts in.
+		interactive: boolean = false,
 	): Promise<void> {
 		if (!this.session?.accessToken) {
 			throw new Error("No GitHub authentication token available");
@@ -340,15 +451,28 @@ export class CopilotChatProvider {
 		} catch (error: any) {
 			console.error("Error getting Copilot token:", error);
 
-			// Log token retrieval failure with standardized telemetry
-			logError(error, "copilot-token-retrieval", {
-				clientId: GITHUB_COPILOT_CLIENT_ID,
-				context: "token-exchange",
-			});
+			// During a background probe, an expired device code or an offline
+			// network is the expected steady state, not a user-facing error
+			// (issue #58.3). Route those to a non-error signal; surface everything
+			// else, and anything from a user-initiated flow, as an error.
+			// error_site renamed off 'copilot-token-retrieval': the substring
+			// 'token' is PII-scrubbed by the telemetry sender, which blinded these
+			// events (issue #58.1). 'copilot-credential-exchange' is clean.
+			if (!interactive && isExpectedBackgroundAuthFailure(error)) {
+				logAuthUnavailable(error, "copilot-credential-exchange");
+			} else {
+				logError(error, "copilot-credential-exchange", {
+					clientId: GITHUB_COPILOT_CLIENT_ID,
+				});
+			}
 
-			throw new Error(
+			// Mark the wrapper so the initializeSession catch doesn't re-report a
+			// failure we've already classified here (avoids a duplicate signal).
+			const wrapped = new Error(
 				`Failed to authenticate with GitHub Copilot: ${error.message}`,
 			);
+			(wrapped as { telemetryReported?: boolean }).telemetryReported = true;
+			throw wrapped;
 		}
 	}
 
@@ -435,6 +559,42 @@ export class CopilotChatProvider {
 		}
 	}
 
+	/**
+	 * Resolves the chat model from the live Copilot /models catalog and stores it
+	 * in this._baseModel for the provider getter to use. Safe to call during
+	 * initialization: it never throws and never hangs — getModelId() is raced
+	 * against a timeout, and any failure (network error, empty catalog, timeout)
+	 * falls back to a known-good GA model so provider construction always has a
+	 * valid model id.
+	 */
+	private async resolveBaseModel(): Promise<void> {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		try {
+			const timeout = new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error("model resolution timed out")),
+					MODEL_RESOLUTION_TIMEOUT_MS,
+				);
+				timer.unref?.();
+			});
+			const modelId = await Promise.race([this.getModelId(), timeout]);
+			if (typeof modelId === "string" && modelId.length > 0) {
+				return; // getModelId already set this._baseModel/_modelCapabilities
+			}
+			throw new Error("empty model id from catalog");
+		} catch (error) {
+			console.warn(
+				`Falling back to ${FALLBACK_MODEL_ID}; live model resolution failed`,
+				error,
+			);
+			this._baseModel = FALLBACK_MODEL_ID;
+		} finally {
+			if (timer) {
+				clearTimeout(timer);
+			}
+		}
+	}
+
 	async getModelId() {
 		try {
 			const response = await fetch(`${this._baseUrl}/models`, {
@@ -466,11 +626,14 @@ export class CopilotChatProvider {
 				throw new Error("No enabled models found");
 			}
 
-			// Find models matching the models we want in the exact order of preference
+			// Find models matching the models we want in the exact order of
+			// preference. claude-sonnet-4.6 leads (safest for structured README
+			// extraction) followed by the GA gpt-5.3-codex. 'gpt-5.2-codex' is
+			// deliberately omitted: GitHub retired it 2026-06-01 and selecting it
+			// produces a 4xx on every request (issue #57).
 			const preferredModelIds = [
 				"claude-sonnet-4.6",
 				"gpt-5.3-codex",
-				"gpt-5.2-codex",
 				"gpt-5.1-codex",
 				"gpt-5.1-codex-codex-max",
 			];

--- a/web/src/components/RepoCard.tsx
+++ b/web/src/components/RepoCard.tsx
@@ -12,7 +12,7 @@ import { Star, Code2, CalendarDays, BookText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useVscodeApi } from "@/contexts/VscodeApiContext";
 import { Messenger } from "vscode-messenger-webview";
-import { aiAssistedSetupType, cloudMCPInterestType, previewReadmeType } from "../../../src/shared/types/rpcTypes.ts";
+import { aiAssistedSetupType, cloudMCPInterestType, previewReadmeType, type CloudMcpInterestSurface } from "../../../src/shared/types/rpcTypes.ts";
 interface CloudMcpCheckResult {
   success: boolean;
   exists: boolean;
@@ -55,15 +55,18 @@ const RepoCard: React.FC<RepoCardProps> = ({ repo }) => {
     });
   };
 
-  const handleCloudMCPClick = () => {
-    // Send telemetry event with repo URL
+  const handleCloudMCPClick = (surface: CloudMcpInterestSurface = 'repo_card') => {
+    // Send telemetry event with repo URL. `surface` distinguishes a normal
+    // deploy click from one driven by an AI-assisted-setup failure so the two
+    // can be told apart in the funnel.
     messenger.sendNotification(cloudMCPInterestType, {
       type: 'extension'
     }, {
       repoName: repo.fullName,
       repoOwner: repo.author.name,
       repoUrl: repo.url,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
+      surface
     });
   };
 
@@ -183,7 +186,7 @@ const RepoCard: React.FC<RepoCardProps> = ({ repo }) => {
               </Button>
               <Button
                 variant={"outline"}
-                onClick={handleCloudMCPClick}
+                onClick={() => handleCloudMCPClick('repo_card')}
                 className="flex-1 bg-[var(--vscode-button-background)] hover:border-[var(--vscode-button-border)] hover:bg-[var(--vscode-button-hoverBackground)] "
               >
                 Deploy on CloudMCP
@@ -192,7 +195,7 @@ const RepoCard: React.FC<RepoCardProps> = ({ repo }) => {
           ) : (
             <Button
               variant={"outline"}
-              onClick={handleCloudMCPClick}
+              onClick={() => handleCloudMCPClick('repo_card')}
               className="w-full bg-[var(--vscode-button-background)] hover:border-[var(--vscode-button-border)] hover:bg-[var(--vscode-button-hoverBackground)] "
             >
               Deploy on CloudMCP
@@ -216,7 +219,7 @@ const RepoCard: React.FC<RepoCardProps> = ({ repo }) => {
             </Button>
             <Button
               variant={"outline"}
-              onClick={handleCloudMCPClick}
+              onClick={() => handleCloudMCPClick('ai_setup_failure')}
               className="flex-1 bg-[var(--vscode-button-background)] hover:border-[var(--vscode-button-border)] hover:bg-[var(--vscode-button-hoverBackground)] "
             >
               Deploy on CloudMCP


### PR DESCRIPTION
## Summary
Built from day-1 telemetry of the 0.0.93/0.0.94 wave. Opus 4.8 implemented; Fable adversarially reviewed.

- **#57 — AI-assisted setup works again.** It was failing 100% (`AxGenerateError: Generate failed`) because GitHub retired the hardcoded `gpt-5.2-codex` model on 2026-06-01. We now resolve the model from the live Copilot `/models` catalog via the previously-dead `getModelId()`, timeout-guarded with a `gpt-5.3-codex` fallback so it can never hang or throw activation.
- **#57 — observability + fallback measurability.** The real HTTP status (`error.cause`) is now logged on extract failures, and failure-driven "Deploy on CloudMCP" clicks are attributed separately (`deploy-setup-fallback`) so we can measure failure→hosted conversion.
- **#58 — telemetry/UX nits.** Renamed telemetry sites VS Code was redacting as secrets (`github-signin`, `copilot-credential-exchange`); markdown-preview fallback so forks without the markdown extension still get the What's New impression; expected background auth-probe failures route to a non-error signal instead of `error.general` (was ~80% of error volume).

## Verification
compile ✅ lint ✅ web build ✅ `vsce package` ✅ headless VS Code tests exit 0 ✅ (run twice). 3 Fable reviewers; **2 must-fixes** found and fixed — the standout being a double `error.general` emit that Opus self-flagged and Fable independently caught (resolved to a single correlated event carrying the cause props), plus release-note overclaims corrected to match the diff. Dependabot 70→3 (0 critical) from the 0.0.94 cleanup.

## Follow-up (pre-existing, not introduced here)
Fable flagged a latent activation-hang risk: the silent activation auth probe can enter the device-code polling loop. Predates this diff; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic AI model selection for assisted setup from available Copilot catalog with automatic fallback
  * Fallback display options for What's New notes on VS Code forks

* **Bug Fixes**
  * Enhanced setup failure diagnostics with detailed HTTP/error information
  * Improved telemetry accuracy for setup and authentication errors
  * Refined CloudMCP deployment tracking to distinguish normal vs. failure-recovery flows

* **Documentation**
  * Version 0.0.95 release notes published

<!-- end of auto-generated comment: release notes by coderabbit.ai -->