### PR TITLE
release 0.0.96: fix Copilot activation hang (#60) + release-note cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 *Sponsored by [Cloud MCP](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=marketplace&utm_campaign=marketplace-changelog) – Deploy remote MCP servers in seconds.*
 
+## [0.0.96] - 2026-06-12
+
+### Fixed
+
+- Faster, quieter startup: the extension no longer stalls at launch, or shows an unexpected GitHub sign-in prompt, when GitHub Copilot isn't available (no Copilot seat or a transient server error). Sign-in now happens only when you actually use a Copilot-powered feature, instead of during a silent background check at activation.
+
 ## [0.0.95] - 2026-06-12
 
 ### Fixed
 
 - AI-assisted setup works again. It was hardcoded to the `gpt-5.2-codex` Copilot model, which GitHub retired on 2026-06-01, causing every setup attempt to fail. The extension now resolves a currently-available model from your Copilot account's live `/models` catalog (preferring `claude-sonnet-4.6`, then `gpt-5.3-codex`), with a known-good fallback if the catalog can't be reached.
-- AI-assisted setup failures now surface the real underlying cause (including the actual HTTP status and error returned by the language model) to diagnostics, instead of a generic, undiagnosable failure.
+- AI-assisted setup failures now surface the real underlying cause (including the actual HTTP status and error returned by the language model), instead of a generic, undiagnosable failure.
 - The What's New notes now render on VS Code forks/OSS builds that don't ship the built-in Markdown preview command, falling back to opening the notes as a document or on the web.
-
-### Changed
-
-- Failure-driven "Deploy on CloudMCP" clicks (from the failed-setup card) are now attributed separately from normal repo-card deploys — distinct campaign plus a `surface` telemetry property — so we can tell how often the hosted fallback rescues a failed setup. The destination is unchanged.
-- Error and auth telemetry was tightened — still minimal and anonymous; see the Telemetry section in the README for what is collected.
 
 ## [0.0.94] - 2026-06-11
 
@@ -30,12 +31,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Registry searches that hit an API error now show "Search failed — try again" instead of being indistinguishable from zero results.
 - The failed-setup card now explains that setup failed and offers the hosted CloudMCP fallback alongside Retry Install.
-- Install and error telemetry was tightened — still minimal and anonymous; see the Telemetry section in the README for what is collected.
 - CI: GitHub Actions workflows updated to current action versions.
 
 ### Fixed
 
-- AI-assisted setup failures no longer report a generic "no result returned" — the real underlying error (including language-model errors) is surfaced to logs and diagnostics.
+- AI-assisted setup failures no longer report a generic "no result returned" — the real underlying error (including language-model errors) is surfaced to the logs.
 - Remote MCP servers installed to VS Code now use VS Code's native config shape (explicit `http`/`sse` type and a plain header map), so remote installs from registry cards produce valid `mcp.json` entries.
 - Git hooks (`.husky`) are no longer packaged into the extension, and the dependency lockfiles were refreshed: orphaned packages pruned and in-range dependency updates picked up (including runtime dependencies such as axios, ai, undici, and ws; no `package.json` ranges changed).
 
@@ -44,11 +44,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - "Deploy on CloudMCP" now opens the CloudMCP discover page with a search prefilled for the server you clicked, instead of a generic landing page.
-- Telemetry section in the README documenting what the extension collects and how to disable it.
 
 ### Changed
 
-- Telemetry overhauled: the old, broken pipeline was removed entirely. The new telemetry is minimal and anonymous (basic usage events like search/install/link clicks, including truncated search terms — no file contents, no account identifiers) and respects VS Code's `telemetry.telemetryLevel` setting.
 - Refreshed the Discord invite link and README formatting.
 
 ### Fixed
@@ -145,7 +143,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Marketplace metadata updates and deploy URL tracking parameters.
+- Marketplace metadata updates.
 
 ## [0.0.82] - 2025-09-16
 

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -5,40 +5,24 @@
 ## Version 0.0.95 - AI-Assisted Setup Works Again
 *(June 12 2026)*
 
-AI-assisted setup had stopped working: it was pinned to a GitHub Copilot model that was retired on June 1, so every setup attempt failed. This release picks a live model automatically and makes failures explain themselves — and when setup still can't complete, the existing hosted fallback now reports separately so we can see how often it rescues a failed setup.
-
 What's new
 
-- **AI-assisted setup picks a working model automatically.** It was hardwired to a single Copilot model (`gpt-5.2-codex`) that GitHub retired on June 1 2026 — so once that model went away, every AI-assisted setup failed. The extension now queries your Copilot account's live list of available models and uses one that's actually enabled (preferring Claude Sonnet 4.6, then the current GPT-5.3 Codex), with a known-good default if the list can't be reached. Setup works again, and it won't break the next time a single model is retired.
-- **Failures explain themselves.** When AI-assisted setup can't finish, the real underlying reason (including the actual error returned by the language model) now reaches the diagnostics instead of a generic "it failed" — so a problem can be understood and fixed instead of guessed at.
-- **The hosted fallback now reports separately.** When AI-assisted setup fails, the card's existing **Deploy on CloudMCP** button still takes you to the [hosted catalog](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=whats-new-0.0.95) for that server — and those failure-driven clicks are now attributed apart from ordinary repo-card deploys, so we can tell how often the fallback rescues a failed setup.
-- **The What's New notes show up everywhere.** On VS Code forks that don't ship the built-in Markdown preview, these notes now open as a document (or on the web) instead of silently failing.
-- **Telemetry tune-up** for error and auth reporting — still minimal and anonymous; details in the [README Telemetry section](https://github.com/VikashLoomba/copilot-mcp#telemetry).
+- **AI-assisted setup works again.** It now automatically uses whichever Copilot model is available on your account, so one-click setup from a repo just works.
 
 ## Version 0.0.94 - The Installed Tab Sees Everything + Run on CloudMCP
 *(June 11 2026)*
 
-This release makes the Installed tab show every MCP server VS Code knows about — including the ones this extension installs — and gives you a hosted option wherever a local install can't help.
-
 What's new
 
-- **The Installed tab now shows servers from VS Code's user-level `mcp.json`** — where VS Code stores user-scope MCP servers since 1.102, including every server you install with this extension's VS Code button. Your own installs finally show up. These entries are read-only for now: if you try to edit or delete one, the extension points you to the **MCP: Open User Configuration** command.
-- **Run on CloudMCP, right from Official Registry cards.** Every registry card now has a [Run on CloudMCP](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=whats-new-0.0.94) button alongside VS Code, Claude Code, and Codex — and when a server can't be installed locally, or your registry search comes up empty, a one-click link takes you to the hosted catalog with the server or search prefilled.
-- **Remote servers now install into VS Code in VS Code's native config shape** (explicit `http`/`sse` type and a plain header map), so "Add Remote to VS Code" from registry cards produces entries VS Code actually accepts.
-- **Clearer failures.** A registry search that hits an API error now says "Search failed — try again" instead of pretending there were no results, and when AI-assisted setup fails the card now tells you what happened and offers the hosted fallback — while the logs capture the real underlying error instead of a generic message.
-- **Leaner, more reliable releases:** git hooks are no longer bundled into the extension package, the dependency lockfiles were refreshed (orphaned packages pruned and in-range dependency updates picked up — including runtime dependencies like axios and undici), and CI/release workflows were updated.
-- **Telemetry tune-up** for install and error reporting — still minimal and anonymous; details in the [README Telemetry section](https://github.com/VikashLoomba/copilot-mcp#telemetry).
+- **The Installed tab now shows every MCP server you've installed** — including the ones you add with this extension's VS Code button, which previously didn't show up.
+- **Run on CloudMCP, right from Official Registry cards.** Every registry card now has a [Run on CloudMCP](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=vscode&utm_campaign=whats-new-0.0.94) button alongside VS Code, Claude Code, and Codex — a hosted option whenever a local install isn't what you want.
 
-## Version 0.0.93 - Telemetry Overhaul + Smarter CloudMCP Deploys
+## Version 0.0.93 - Smarter CloudMCP Deploys
 *(June 11 2026)*
 
-This release replaces the old telemetry pipeline and makes "Deploy on CloudMCP" land you exactly where you need to be.
-
 What's new
 
-- **Telemetry overhauled.** The old, broken telemetry pipeline has been removed entirely. The new telemetry is minimal and anonymous — basic usage events like search/install/link clicks, including the search terms you type (truncated), with no file contents and no account identifiers — and it fully respects VS Code's telemetry settings. Details in the [README Telemetry section](https://github.com/VikashLoomba/copilot-mcp#telemetry).
 - **"Deploy on CloudMCP" now takes you to a search prefilled for the server you clicked**, instead of a generic landing page.
-- **Reliability and CI fixes**, including more resilient release packaging.
 
 ## Version 0.0.91 - Installed Skills Management + CI Test Automation
 *(February 16 2026)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-mcp",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-mcp",
-      "version": "0.0.95",
+      "version": "0.0.96",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^0.2.14",
         "@ax-llm/ax": "^14.0.16",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "displayName": "Copilot MCP + Agent Skills Manager",
   "description": "Search, manage, and install Skills and MCP servers for your AI agents.",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "icon": "logo.png",
   "engines": {
     "vscode": "^1.104.0"

--- a/src/utilities/CopilotChat.ts
+++ b/src/utilities/CopilotChat.ts
@@ -355,6 +355,22 @@ export class CopilotChatProvider {
 				"Could not get Copilot token from GitHub API, falling back to device flow",
 			);
 
+			// The device-code flow shows a sign-in notification and then polls
+			// github.com every ~5s in a while(!authenticated) loop until the code
+			// expires (~15 min). That is only acceptable for a genuine, user-
+			// initiated sign-in. During a background probe (interactive === false,
+			// e.g. the activation-time silent init in initializeSession(false)) it
+			// must NEVER run: it would hang activation and spam "device_code has
+			// expired" (issue #60). Fail fast instead — the thrown error is matched
+			// by isExpectedBackgroundAuthFailure below, so it is recorded as the
+			// non-error ext.auth.unavailable signal and Copilot stays unconfigured
+			// until the user acts.
+			if (!interactive) {
+				throw new Error(
+					"Copilot authentication required (background) — sign in to enable AI features [device_code flow skipped]",
+				);
+			}
+
 			// If direct token retrieval failed, we need to initiate the device code flow
 			// Step 1: Request device code
 			const deviceCodeResponse = await fetch(


### PR DESCRIPTION
## Summary
- **#60 — activation hang fixed.** The background activation probe could fall into the OAuth device-code polling loop (~15 min, awaited from `activate()`) and pop an unprompted sign-in when Copilot was unavailable. The device-code flow is now gated on the `interactive` flag: background probes fail fast (routed to the existing expected `auth.unavailable` signal); genuine user-initiated sign-in still runs the full flow. Fable verified every user-initiated path reaches `interactive=true`, so sign-in is not regressed.
- **Release notes cleaned up.** All telemetry mentions stripped from CHANGELOG + WHATS_NEW; WHATS_NEW 0.0.93–0.0.95 trimmed to user-facing feature highlights only (bug-fix/reliability/technical detail belongs in the changelog). No WHATS_NEW entry for 0.0.96 — it's a bug-fix release.

## Verification
compile ✅ lint ✅ web build ✅ `vsce package` ✅ headless VS Code tests exit 0 ✅. Opus implemented; **Fable adversarially reviewed — 0 must-fixes** (gate confirmed correct, telemetry sweep clean). Two advisory accuracy nits fixed in the notes; the one medium advisory (background token-fetch has no timeout — a separate black-holed-network stall path) filed as #62 rather than expanding this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.0.96

* **New Features**
  * Added "Run on CloudMCP" button to Official Registry cards
  * "Deploy on CloudMCP" now opens search prefilled with the selected server

* **Bug Fixes**
  * Faster and quieter startup by deferring GitHub sign-in until Copilot features are accessed
  * Improved error messaging for AI-assisted setup failures
  * Fixed Copilot model resolution issues

* **Documentation**
  * Updated release notes for versions 0.0.93–0.0.96

<!-- end of auto-generated comment: release notes by coderabbit.ai -->