### PR TITLE
release 0.0.97: fix AI-assisted setup model routing (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 *Sponsored by [Cloud MCP](https://cloudmcp.run/?utm_source=copilot-mcp&utm_medium=marketplace&utm_campaign=marketplace-changelog) – Deploy remote MCP servers in seconds.*
 
+## [0.0.97] - 2026-06-15
+
+### Fixed
+
+- AI-assisted setup now selects a Copilot model your account can actually use. It was picking models that aren't available for chat completions — either ones your account hadn't enabled, or ones that only work on a different API — so setup failed. The extension now only chooses chat-compatible, enabled models from your Copilot catalog, with a universally available fallback.
+
 ## [0.0.96] - 2026-06-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-mcp",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-mcp",
-      "version": "0.0.96",
+      "version": "0.0.97",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^0.2.14",
         "@ax-llm/ax": "^14.0.16",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "displayName": "Copilot MCP + Agent Skills Manager",
   "description": "Search, manage, and install Skills and MCP servers for your AI agents.",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "icon": "logo.png",
   "engines": {
     "vscode": "^1.104.0"

--- a/src/test/modelSelection.test.ts
+++ b/src/test/modelSelection.test.ts
@@ -1,0 +1,96 @@
+import * as assert from "assert";
+
+import {
+	isChatCallableEnabledModel,
+	selectChatModel,
+} from "../utilities/modelSelection";
+
+// Regression coverage for issue #57: AI-assisted setup failed 100% with HTTP 400
+// model_not_supported because getModelId() picked models that aren't usable on
+// the /chat/completions endpoint @ax-llm/ax targets — a policy-disabled (but
+// picker-enabled) model, and a /responses-only model. The selection must only
+// ever return a model that is BOTH chat-callable and enabled.
+suite("modelSelection", () => {
+	// A picker-enabled model whose account policy is disabled — un-callable.
+	const disabledPicker = {
+		id: "claude-sonnet-4.6",
+		model_picker_enabled: true,
+		supported_endpoints: ["/chat/completions"],
+		policy: { state: "disabled" },
+	};
+	// A picker-enabled model that only speaks the Responses API — never callable
+	// on /chat/completions (this was the old FALLBACK_MODEL_ID, gpt-5.3-codex).
+	const responsesOnly = {
+		id: "gpt-5.3-codex",
+		model_picker_enabled: true,
+		supported_endpoints: ["/responses"],
+		policy: { state: "enabled" },
+	};
+	// A plain chat-callable, enabled model.
+	const chatCallable = {
+		id: "gpt-4o",
+		model_picker_enabled: true,
+		supported_endpoints: ["/chat/completions"],
+		policy: { state: "enabled" },
+	};
+
+	const preferred = [
+		"claude-sonnet-4.6",
+		"gpt-5.3-codex",
+		"gpt-5.1-codex",
+	];
+
+	test("selects the chat-callable enabled model, never disabled/responses-only", () => {
+		const catalog = [disabledPicker, responsesOnly, chatCallable];
+		const selected = selectChatModel(catalog, preferred);
+		assert.ok(selected, "a usable model should be selected");
+		assert.strictEqual(selected!.id, "gpt-4o");
+	});
+
+	test("isChatCallableEnabledModel rejects disabled and responses-only", () => {
+		assert.strictEqual(isChatCallableEnabledModel(disabledPicker), false);
+		assert.strictEqual(isChatCallableEnabledModel(responsesOnly), false);
+		assert.strictEqual(isChatCallableEnabledModel(chatCallable), true);
+	});
+
+	test("ignores model_picker disabled models", () => {
+		const notPickable = {
+			id: "internal-model",
+			model_picker_enabled: false,
+			supported_endpoints: ["/chat/completions"],
+			policy: { state: "enabled" },
+		};
+		assert.strictEqual(isChatCallableEnabledModel(notPickable), false);
+	});
+
+	test("honors preference order among callable models", () => {
+		const sonnetEnabled = {
+			...disabledPicker,
+			policy: { state: "enabled" },
+		};
+		const catalog = [chatCallable, sonnetEnabled];
+		const selected = selectChatModel(catalog, preferred);
+		// sonnet leads the preference list and is now callable, so it wins.
+		assert.strictEqual(selected!.id, "claude-sonnet-4.6");
+	});
+
+	test("fails open when supported_endpoints / policy are absent", () => {
+		const leanCatalog = [{ id: "lean", model_picker_enabled: true }];
+		assert.strictEqual(
+			isChatCallableEnabledModel(leanCatalog[0]),
+			true,
+			"absent fields must not over-filter a usable model",
+		);
+		const selected = selectChatModel(leanCatalog, preferred);
+		assert.strictEqual(selected!.id, "lean");
+	});
+
+	test("returns null on an empty / all-unusable catalog (caller uses fallback)", () => {
+		assert.strictEqual(selectChatModel([], preferred), null);
+		assert.strictEqual(
+			selectChatModel([disabledPicker, responsesOnly], preferred),
+			null,
+		);
+		assert.strictEqual(selectChatModel(undefined, preferred), null);
+	});
+});

--- a/src/test/tsconfig.json
+++ b/src/test/tsconfig.json
@@ -3,8 +3,13 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "rootDir": ".",
-    "outDir": "../../out/test",
+    // rootDir is the src/ tree (not just src/test) so test files can import the
+    // pure, vscode-free helpers they exercise (e.g. ../utilities/modelSelection)
+    // without tripping TS6059 "not under rootDir". outDir is the matching out/
+    // root, which keeps compiled tests at out/test/**/*.test.js — the path the
+    // vscode-test runner globs (see .vscode-test.mjs) — and out/test/ui/runTest.js.
+    "rootDir": "..",
+    "outDir": "../../out",
     "types": ["node", "mocha"]
   },
   "include": ["**/*.ts"]

--- a/src/utilities/CopilotChat.ts
+++ b/src/utilities/CopilotChat.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 
 import { ai, AxAI, AxAIOpenAIModel } from "@ax-llm/ax";
 import { logError, logEvent } from "../telemetry/standardizedTelemetry";
+import { selectChatModel } from "./modelSelection";
 
 const GITHUB_AUTH_PROVIDER_ID = "github";
 // The GitHub Authentication Provider accepts the scopes described here:
@@ -10,10 +11,12 @@ const SCOPES = ["user:email", "read:org", "read:user"];
 const GITHUB_COPILOT_CLIENT_ID = "Iv1.b507a08c87ecfe98"; // This is a public client ID for Copilot
 
 // Known-good fallback model used when the live Copilot /models catalog cannot
-// be reached or returns nothing usable. Must be a currently-GA Copilot model:
-// 'gpt-5.2-codex' was retired 2026-06-01, so we lead getModelId() with
-// claude-sonnet-4.6 (safest for structured extraction) and fall back here.
-const FALLBACK_MODEL_ID = "gpt-5.3-codex";
+// be reached or returns nothing usable. Must be a model that is universally
+// chat-callable on /chat/completions and needs no per-account opt-in: 'gpt-4o'
+// is a base model available to every Copilot account. (Earlier fallbacks were
+// un-callable here — 'gpt-5.2-codex' was retired 2026-06-01, and 'gpt-5.3-codex'
+// is Responses-API-only, so it 400'd every chat request, issue #57.)
+const FALLBACK_MODEL_ID = "gpt-4o";
 // Upper bound on the live /models lookup during provider construction so a slow
 // or hung catalog request can never stall initialization; on timeout we use the
 // fallback model instead.
@@ -632,21 +635,17 @@ export class CopilotChatProvider {
 			console.log("Available models:", JSON.stringify(data, null, 2));
 
 			const models = data.data;
-			// filter out the models that are not enabled for the current editor
-			const enabledModels = models.filter(
-				(model: any) => model.model_picker_enabled,
-			);
 
-			if (enabledModels.length === 0) {
-				console.error("No enabled models found");
-				throw new Error("No enabled models found");
-			}
-
-			// Find models matching the models we want in the exact order of
-			// preference. claude-sonnet-4.6 leads (safest for structured README
-			// extraction) followed by the GA gpt-5.3-codex. 'gpt-5.2-codex' is
+			// Models in the exact order of preference. claude-sonnet-4.6 leads
+			// (safest for structured README extraction). 'gpt-5.2-codex' is
 			// deliberately omitted: GitHub retired it 2026-06-01 and selecting it
-			// produces a 4xx on every request (issue #57).
+			// produces a 4xx on every request (issue #57). The capable codex ids
+			// are kept here on purpose — selectChatModel filters the catalog to
+			// only models that are chat-callable on /chat/completions AND not
+			// policy-disabled, so an un-callable or un-opted-in preference (e.g.
+			// a /responses-only model, or sonnet before the account opts in) is
+			// dropped at runtime, while a paid seat that has it enabled still
+			// gets it.
 			const preferredModelIds = [
 				"claude-sonnet-4.6",
 				"gpt-5.3-codex",
@@ -654,28 +653,30 @@ export class CopilotChatProvider {
 				"gpt-5.1-codex-codex-max",
 			];
 
-			// Instead of filter, we'll find the first model that matches our preferences in order
-			for (const preferredId of preferredModelIds) {
-				const foundModel = enabledModels.find(
-					(model: any) => model.id === preferredId,
+			// Both the preference match and the first-available fallback are
+			// drawn only from the chat-callable+enabled subset, so every returned
+			// id is one a chat-completions request can actually use.
+			const selected = selectChatModel(models, preferredModelIds);
+
+			if (!selected) {
+				// Odd/empty catalog (no chat-callable enabled model). Don't throw
+				// or index undefined — fall back to the universally chat-callable
+				// FALLBACK_MODEL_ID so provider construction always has a valid id.
+				console.warn(
+					`No chat-callable enabled models found; using ${FALLBACK_MODEL_ID}`,
 				);
-				if (foundModel) {
-					this.modelDetails = foundModel;
-					console.log(`Selected model: ${foundModel.id}`);
-					this._baseModel = foundModel.id;
-					this._modelCapabilities = foundModel.capabilities;
-					console.log(`Model capabilities:`, this._modelCapabilities);
-					return foundModel.id;
-				}
+				this._baseModel = FALLBACK_MODEL_ID;
+				this._modelCapabilities = null;
+				this.modelDetails = null;
+				return this._baseModel;
 			}
 
-			// If none of our preferred models are available, use the first enabled model
-			this._baseModel = enabledModels[0].id;
-			this._modelCapabilities = enabledModels[0].capabilities;
-			this.modelDetails = enabledModels[0];
-			console.log(`Using first available model: ${this._baseModel}`);
+			this.modelDetails = selected;
+			this._baseModel = selected.id;
+			this._modelCapabilities = selected.capabilities;
+			console.log(`Selected model: ${selected.id}`);
 			console.log(`Model capabilities:`, this._modelCapabilities);
-			return this._baseModel;
+			return selected.id;
 		} catch (error) {
 			console.error("Error getting models:", error);
 			throw error;

--- a/src/utilities/modelSelection.ts
+++ b/src/utilities/modelSelection.ts
@@ -1,0 +1,74 @@
+// Pure, dependency-free model-selection logic shared by CopilotChat.getModelId().
+// Kept free of any `vscode` import so it can be unit-tested directly (see
+// src/test/modelSelection.test.ts) without the extension host.
+
+/**
+ * Minimal shape of a Copilot /models catalog entry that we rely on. The live
+ * catalog is external and untyped, so every field is optional and accessed
+ * defensively; unknown fields are ignored.
+ */
+export interface CopilotCatalogModel {
+	id: string;
+	model_picker_enabled?: boolean;
+	supported_endpoints?: string[];
+	policy?: { state?: string };
+	capabilities?: unknown;
+	[key: string]: unknown;
+}
+
+/**
+ * Returns true when a catalog model is BOTH chat-callable and enabled, i.e. it
+ * can actually be used against the /chat/completions endpoint that @ax-llm/ax
+ * targets. Three conditions, each fail-open so an absent field never
+ * over-filters an otherwise-usable model out of the list (issue #57):
+ *   - model_picker_enabled is set (the editor surfaces it);
+ *   - supported_endpoints includes "/chat/completions" — but if the field is
+ *     absent we assume callable (?? true), so a leaner catalog isn't emptied;
+ *   - policy.state is not "disabled" — if absent we assume enabled
+ *     (?? "enabled"), so accounts whose catalog omits policy aren't filtered.
+ */
+export function isChatCallableEnabledModel(
+	model: CopilotCatalogModel | null | undefined,
+): boolean {
+	if (!model) {
+		return false;
+	}
+	if (!model.model_picker_enabled) {
+		return false;
+	}
+	const chatCallable =
+		model.supported_endpoints?.includes?.("/chat/completions") ?? true;
+	const enabled = (model.policy?.state ?? "enabled") !== "disabled";
+	return chatCallable && enabled;
+}
+
+/**
+ * Selects the model id to use from a live Copilot /models catalog.
+ *
+ * Guarantees the returned id is one a chat-completions request can actually use:
+ * the catalog is first filtered to models that are both chat-callable and
+ * enabled (isChatCallableEnabledModel), and the result is drawn ONLY from that
+ * filtered set — both the preference matches and the [0] fallback. If the
+ * filter yields nothing (e.g. an odd/empty catalog) we return `fallback`
+ * instead of throwing or indexing undefined.
+ *
+ * @returns the chosen catalog model, or null when no usable model exists (the
+ *          caller then uses its hardcoded fallback id).
+ */
+export function selectChatModel(
+	models: CopilotCatalogModel[] | null | undefined,
+	preferredModelIds: readonly string[],
+): CopilotCatalogModel | null {
+	const list = Array.isArray(models) ? models : [];
+	const enabledModels = list.filter(isChatCallableEnabledModel);
+	if (enabledModels.length === 0) {
+		return null;
+	}
+	for (const preferredId of preferredModelIds) {
+		const found = enabledModels.find((model) => model.id === preferredId);
+		if (found) {
+			return found;
+		}
+	}
+	return enabledModels[0];
+}


### PR DESCRIPTION
## Summary
Real fix for #57 — reproduced live against the Copilot API. AI-assisted setup was failing 100% with `400 model_not_supported` because `getModelId()` selected models the account can't call on `/chat/completions` (the endpoint @ax-llm/ax uses): the preferred `claude-sonnet-4.6` is `policy.state: disabled` until opt-in, and the fallback `gpt-5.3-codex` is Responses-API-only.

- Filter the live `/models` catalog to chat-callable + enabled: require `supported_endpoints` includes `/chat/completions` and `policy.state != disabled` (both fail-open if absent), plus the existing `model_picker_enabled`.
- `FALLBACK_MODEL_ID`: `gpt-5.3-codex` → `gpt-4o` (universally chat-callable).
- Empty-filter case returns the fallback instead of throwing (activation-safe).
- Pure selection logic extracted to `modelSelection.ts` + unit test (6 cases: disabled/responses-only exclusion, preference ordering, fail-open, empty→null).
- CHANGELOG entry. **No WHATS_NEW change** (bug-fix release).

Per-account: a paid seat with Sonnet enabled still gets Sonnet; everyone else lands on a working model.

## Verification
compile ✅ lint ✅ web build ✅ `vsce package` ✅ **11 tests passing** (incl. new modelSelection suite) ✅. Opus implemented; **Sonnet** adversarially reviewed (Fable was transiently unavailable as a subagent) — **0 must-fixes**; filter-correctness and activation-safety both clean.

Note: leaving #57 OPEN until field telemetry confirms `ai_setup` success rate goes >0 on 0.0.97 clients — we've declared this fixed prematurely twice, so it stays open until the data proves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AI-assisted setup failures caused by selecting unavailable Copilot models. Now intelligently selects only chat-compatible and enabled models from your catalog, with a universal fallback option.

* **Tests**
  * Expanded test coverage for model selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->